### PR TITLE
avoid holding thread lock while doing work - bug 229

### DIFF
--- a/XDMA/linux-kernel/xdma/xdma_thread.c
+++ b/XDMA/linux-kernel/xdma/xdma_thread.c
@@ -119,7 +119,9 @@ static int xthread_main(void *data)
 					thp->name, thp->work_cnt);
 			/* do work */
 			list_for_each_safe(work_item, next, &thp->work_list) {
+				unlock_thread(thp);
 				thp->fproc(work_item);
+				lock_thread(thp);
 			}
 		}
 		unlock_thread(thp);


### PR DESCRIPTION
This certainly appears to work, but might not be correct if the list of work might have work being deleted elsewhere